### PR TITLE
Remove deprecated fields from step.yml.gotemplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.vscode
 .bitrise*
+.idea
+.vscode
 _bin/*
 _tmp/*

--- a/bitrise-plugin.yml
+++ b/bitrise-plugin.yml
@@ -1,9 +1,9 @@
 name: step
 description: Manage Bitrise CLI steps
 executable:
-  osx: https://github.com/bitrise-io/bitrise-plugins-step/releases/download/0.10.1/bitrise-plugins-step-Darwin-x86_64
-  osx-arm64: https://github.com/bitrise-io/bitrise-plugins-step/releases/download/0.10.1/bitrise-plugins-step-Darwin-arm64
-  linux: https://github.com/bitrise-io/bitrise-plugins-step/releases/download/0.10.1/bitrise-plugins-step-Linux-x86_64
+  osx: https://github.com/bitrise-io/bitrise-plugins-step/releases/download/0.10.2/bitrise-plugins-step-Darwin-x86_64
+  osx-arm64: https://github.com/bitrise-io/bitrise-plugins-step/releases/download/0.10.2/bitrise-plugins-step-Darwin-arm64
+  linux: https://github.com/bitrise-io/bitrise-plugins-step/releases/download/0.10.2/bitrise-plugins-step-Linux-x86_64
 trigger: ""
 requirements:
 - tool: bitrise

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,4 +1,4 @@
-format_version: 7
+format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
@@ -10,28 +10,13 @@ workflows:
   # --- workflows for CI and testing
   test:
     steps:
-    - go-list:
-    - golint:
-    - errcheck:
-    - go-test:
+    - go-list: { }
+    - golint: { }
+    - errcheck: { }
+    - go-test: { }
 
   # ----------------------------------------------------------------
   # --- workflows for Utility
-  deps-update:
-    title: Dep update
-    description: |
-      Used for updating bitrise dependencies with dep
-    steps:
-    - script:
-        title: Dependency update
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            go get -u -v github.com/golang/dep/cmd/dep
-            dep ensure -v
-            dep ensure -v -update
-
   install:
     steps:
     - script:

--- a/create/templates/step.yml.gotemplate
+++ b/create/templates/step.yml.gotemplate
@@ -16,9 +16,6 @@ description: |
 website: {{ .WebsiteURL }}
 source_code_url: {{ .SourceCodeURL }}
 support_url: {{ .SupportURL }}
-host_os_tags:
-  - osx-10.10
-  - ubuntu-16.04
 
 # If this step should be available only for certain project types
 # just uncomment this `project_type_tags` section and include all the
@@ -37,6 +34,7 @@ host_os_tags:
 #   - react-native
 #   - cordova
 #   - ionic
+#   - flutter
 
 # Type tags are used for categorizing steps, for easier step discovery in Step Libraries.
 # You can find more information about type tags in the Step Development Guideline:
@@ -44,7 +42,6 @@ host_os_tags:
 type_tags:
   - {{ .PrimaryTypeTag }}
 
-is_requires_admin_user: true
 is_always_run: false
 is_skippable: false
 run_if: ""

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION ...
-const VERSION = "0.10.1"
+const VERSION = "0.10.2"
 
 // BuildNumber ...
 var BuildNumber = ""


### PR DESCRIPTION
- Adds `.idea` to the `.gitignore` file.
- Removes deprecated fields `host_os_tags` and `is_requires_admin_user` from the `step.yml.gotemplate` file.

Also, I noticed there are some fields currently in the gotemplate file that are not mentioned in our internal docs:

- `description`
- `is_skippable`
- `run_if`

@tothszabi & @Bence1001 could either of you advise on if I should update our documentation to include some/all of these, or if I should remove some/all of these from the gotemplate file?