### PR TITLE
Comment out some properties to denote they are optional

### DIFF
--- a/bitrise-plugin.yml
+++ b/bitrise-plugin.yml
@@ -1,9 +1,9 @@
 name: step
 description: Manage Bitrise CLI steps
 executable:
-  osx: https://github.com/bitrise-io/bitrise-plugins-step/releases/download/0.10.2/bitrise-plugins-step-Darwin-x86_64
-  osx-arm64: https://github.com/bitrise-io/bitrise-plugins-step/releases/download/0.10.2/bitrise-plugins-step-Darwin-arm64
-  linux: https://github.com/bitrise-io/bitrise-plugins-step/releases/download/0.10.2/bitrise-plugins-step-Linux-x86_64
+  osx: https://github.com/bitrise-io/bitrise-plugins-step/releases/download/0.10.3/bitrise-plugins-step-Darwin-x86_64
+  osx-arm64: https://github.com/bitrise-io/bitrise-plugins-step/releases/download/0.10.3/bitrise-plugins-step-Darwin-arm64
+  linux: https://github.com/bitrise-io/bitrise-plugins-step/releases/download/0.10.3/bitrise-plugins-step-Linux-x86_64
 trigger: ""
 requirements:
 - tool: bitrise

--- a/create/templates/step.yml.gotemplate
+++ b/create/templates/step.yml.gotemplate
@@ -42,17 +42,23 @@ support_url: {{ .SupportURL }}
 type_tags:
   - {{ .PrimaryTypeTag }}
 
-is_always_run: false
-is_skippable: false
-run_if: ""
+# These properties define whether a Step is run in a given Workflow or not.
+# You can find more information about this in the documentation here:
+# https://devcenter.bitrise.io/en/steps-and-workflows/developing-your-own-bitrise-step/developing-a-new-step.html#setting-conditions-for-running-the-step
+#
+# is_always_run: false
+# is_skippable: false
+# run_if: ""
 
-deps:
-  brew:
-  - name: git
-  - name: wget
-  apt_get:
-  - name: git
-  - name: wget
+# Use the `deps` property to declare dependencies that you can fetch from an OS dependency manager.
+# You can find more information about this in the documentation here:
+# https://devcenter.bitrise.io/en/steps-and-workflows/developing-your-own-bitrise-step/developing-a-new-step.html#submodules-and-step-dependencies
+#
+# deps:
+#   brew:
+#   - name: cmake
+#   apt_get:
+#   - name: cmake
 
 {{ if eq .ToolkitType "bash" }}
 toolkit:

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION ...
-const VERSION = "0.10.2"
+const VERSION = "0.10.3"
 
 // BuildNumber ...
 var BuildNumber = ""


### PR DESCRIPTION
Because these properties are optional, I think they should be commented out with some extra documentation included, similar to others in the template. This should prevent unnecessary properties being included in Steps going forward.

This PR was born out of some feedback from @koral-- on a recent PR: https://github.com/bitrise-io/bitrise-steplib/pull/3522#discussion_r907652693