### PR TITLE
Fix version override in release build

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-const VERSION = "0.99.999-development"
+var VERSION = "0.99.999-development"
 
 // BuildNumber ...
 var BuildNumber = ""


### PR DESCRIPTION
Fixes a regression in #46 

A `const` can't be overridden using `-ldflags`.